### PR TITLE
Fix: Ditto docker startup failure.

### DIFF
--- a/sandbox/ditto-docker-compose.yml
+++ b/sandbox/ditto-docker-compose.yml
@@ -45,7 +45,7 @@ services:
         aliases:
           - ditto-cluster
     depends_on:
-      - policies
+      - ditto-policies
     environment:
       - TZ=UTC
       - INSTANCE_INDEX=1


### PR DESCRIPTION
`policy` service name is changed to `ditto-policies` but there is a parameter yet to refactor which was leading ditto startup failure.