### PR TITLE
Bugfix/resolving dependency issue due to conflict between vertx classpaths

### DIFF
--- a/core/base/src/main/java/com/nubeiot/core/NubeConfig.java
+++ b/core/base/src/main/java/com/nubeiot/core/NubeConfig.java
@@ -71,6 +71,21 @@ public final class NubeConfig implements IConfig {
                             NubeConfig.class);
     }
 
+    public static NubeConfig constructNubeConfig(@NonNull NubeConfig nubeConfig, @NonNull AppConfig appConfig,
+                                                 boolean checkDeploy) {
+        JsonObject appConfigJson = appConfig.toJson();
+        if(checkDeploy && appConfigJson.containsKey(DeployConfig.NAME)) {
+            DeployConfig deployConfig = IConfig.from(appConfigJson, DeployConfig.class);
+            appConfigJson.remove(DeployConfig.NAME);
+            NubeConfig mergedConfig = new NubeConfig(nubeConfig.getDataDir(), nubeConfig.getSystemConfig(),
+                                                     deployConfig, nubeConfig.getAppConfig());
+            AppConfig cleanedAppConfig = IConfig.from(appConfigJson, AppConfig.class);
+            return constructNubeConfig(mergedConfig, cleanedAppConfig);
+        } else {
+            return constructNubeConfig(nubeConfig, appConfig);
+        }
+    }
+
     @Override
     public String name() { return null; }
 

--- a/core/base/src/test/java/com/nubeiot/core/NubeConfigTest.java
+++ b/core/base/src/test/java/com/nubeiot/core/NubeConfigTest.java
@@ -11,6 +11,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import io.vertx.core.json.JsonObject;
 
 import com.nubeiot.core.NubeConfig.AppConfig;
+import com.nubeiot.core.NubeConfig.DeployConfig;
 import com.nubeiot.core.NubeConfig.SystemConfig;
 import com.nubeiot.core.cluster.ClusterType;
 import com.nubeiot.core.exceptions.NubeException;
@@ -266,6 +267,37 @@ public class NubeConfigTest {
         System.out.println("===========================================");
         System.out.println(merge1.toJson().encodePrettily());
         JSONAssert.assertEquals(mergeJson.encode(), merge1.toJson().encode(), JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void test_construct_nube_config_with_deploy_check() throws JSONException {
+        NubeConfig blank = NubeConfig.blank();
+        String inputAppconfig = "{\"__deploy__\":{\"isolatedClasses\":" +
+                                "[\"io.vertx.reactivex.servicediscovery.*\",\"io" +
+                                ".vertx.reactivex.circuitbreaker.*\"]}," +
+                                "\"__sql__\":{\"dialect\":\"H2\",\"__hikari__\":" +
+                                "{\"jdbcUrl\":\"jdbc:h2:file:/data/db/bios-installer\"}}}";
+
+
+        AppConfig appConfig = IConfig.from(inputAppconfig, AppConfig.class);
+        System.out.println("App config before sending");
+        System.out.println(appConfig.toJson().encodePrettily());
+        NubeConfig nubeConfig = NubeConfig.constructNubeConfig(blank, appConfig, true);
+        System.out.println("===========================================");
+        System.out.println("Final config..");
+        System.out.println(nubeConfig.toJson().encodePrettily());
+
+        JSONAssert.assertEquals("{\"ha\":false,\"instances\":1,\"isolatedClasses\":[\"io.vertx.reactivex" +
+                                ".servicediscovery.*\",\"io.vertx.reactivex.circuitbreaker.*\"]," +
+                                "\"maxWorkerExecuteTime\":60000000000,\"maxWorkerExecuteTimeUnit\":" +
+                                "\"NANOSECONDS\",\"multiThreaded\":false,\"worker\":false," +
+                                "\"workerPoolSize\":20}",
+                                nubeConfig.getDeployConfig().toJson().encode(), JSONCompareMode.STRICT);
+
+        JSONAssert.assertEquals("{\"__sql__\":{\"dialect\":\"H2\",\"__hikari__\":" +
+                                "{\"jdbcUrl\":\"jdbc:h2:file:/data/db" +
+                                "/bios-installer\"}}}",
+                                nubeConfig.getAppConfig().toJson().encode(), JSONCompareMode.STRICT);
     }
 
 }

--- a/edge/bios/build.gradle
+++ b/edge/bios/build.gradle
@@ -3,7 +3,6 @@ ext {
 }
 
 dependencies {
-    compile project(':core:micro') //todo: remove this one, related to issue #141
     compile project(':edge:core')
     compile project(':core:cluster:hazelcast')
     testCompile project(":core:base").sourceSets.test.output

--- a/edge/core/src/main/java/com/nubeiot/edge/core/loader/ModuleLoader.java
+++ b/edge/core/src/main/java/com/nubeiot/edge/core/loader/ModuleLoader.java
@@ -13,6 +13,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.reactivex.core.Vertx;
 
+import com.nubeiot.core.NubeConfig;
 import com.nubeiot.core.dto.JsonData;
 import com.nubeiot.core.dto.RequestData;
 import com.nubeiot.core.enums.State;
@@ -34,8 +35,9 @@ public final class ModuleLoader implements EventHandler {
     public Single<JsonObject> installModule(RequestData data) {
         PreDeploymentResult preResult = JsonData.from(data.body(), PreDeploymentResult.class);
         logger.info("Vertx install module {}...", preResult.getServiceFQN());
-        DeploymentOptions options = new DeploymentOptions().setConfig(
-            constructNubeConfig(preResult.getSystemConfig(), preResult.getAppConfig()).toJson());
+        NubeConfig nubeConfig = constructNubeConfig(preResult.getSystemConfig(), preResult.getAppConfig(), true);
+        DeploymentOptions options = new DeploymentOptions(nubeConfig.getDeployConfig().toJson()).setConfig(
+            nubeConfig.toJson());
         return vertx.rxDeployVerticle(preResult.getServiceFQN(), options).doOnError(throwable -> {
             throw new EngineException(throwable);
         }).map(id -> new JsonObject().put("deploy_id", id));

--- a/sandbox/engine/bios.json
+++ b/sandbox/engine/bios.json
@@ -123,6 +123,12 @@
                   }
                 }
               }
+            },
+            "__deploy__": {
+              "isolatedClasses": [
+                "io.vertx.reactivex.servicediscovery.*",
+                "io.vertx.reactivex.circuitbreaker.*"
+              ]
             }
           }
         },
@@ -132,7 +138,14 @@
             "artifact_id": "gateway",
             "version": "1.0.0-SNAPSHOT",
             "service_name": "edge-gateway"
-          }
+          },
+          "appConfig": {
+          "__deploy__": {
+            "isolatedClasses": [
+              "io.vertx.reactivex.servicediscovery.*",
+              "io.vertx.reactivex.circuitbreaker.*"
+            ]
+          }}
         }
       ]
     }


### PR DESCRIPTION
As discussed on #196 , the issue #141 is resolved by sending deployment options with isolated classes in the app config.
With this approach, the modules/services should pass additional appConfig as shown below if the module/service has issue related with class not found.

```
{
          "metadata": {
            "group_id": "com.nubeiot.edge.module",
            "artifact_id": "jdbc",
            "version": "1.0.0-SNAPSHOT",
            "service_name": "edge-jdbc-demo"
          },
          "appConfig": {
            "__deploy__": {
              "isolatedClasses": [
                "io.vertx.ext.jdbc.*"
              ]
            },
.... // other app configs
          }
 }
```